### PR TITLE
WIP: C#-ify

### DIFF
--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           useConfigFile: true
       - name: Pack
-        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/johnkors/NoCommonsNET/releases/tag/${{ steps.gitversion.outputs.NuGetVersionV2 }}" -o ./releases
+        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }}+${{ steps.gitversion.outputs.VersionSourceSha }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/johnkors/NoCommonsNET/releases/tag/${{ steps.gitversion.outputs.NuGetVersionV2 }}" -o ./releases
       - name: Publish
         run: dotnet nuget push ./releases/NoCommons.${{ steps.gitversion.outputs.NuGetVersionV2 }}.nupkg -k=${{ secrets.NUGETORGAPIKEY }} -s=nuget.org
       - run: git log $(git describe --tags --abbrev=0)..HEAD --oneline

--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           useConfigFile: true
       - name: Pack
-        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }}+${{ steps.gitversion.outputs.VersionSourceSha }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/johnkors/NoCommonsNET/releases/tag/${{ steps.gitversion.outputs.NuGetVersionV2 }}" -o ./releases
+        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }}+${{ steps.gitversion.outputs.ShortSha }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/johnkors/NoCommonsNET/releases/tag/${{ steps.gitversion.outputs.NuGetVersionV2 }}" -o ./releases
       - name: Publish
         run: dotnet nuget push ./releases/NoCommons.${{ steps.gitversion.outputs.NuGetVersionV2 }}.nupkg -k=${{ secrets.NUGETORGAPIKEY }} -s=nuget.org
       - run: git log $(git describe --tags --abbrev=0)..HEAD --oneline

--- a/.github/workflows/PreRelease.yml
+++ b/.github/workflows/PreRelease.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           useConfigFile: true
       - name: Pack
-        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }}+${{ steps.gitversion.outputs.ShortSha }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/johnkors/NoCommonsNET/releases/tag/${{ steps.gitversion.outputs.NuGetVersionV2 }}" -o ./releases
+        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }}-${{ steps.gitversion.outputs.ShortSha }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/johnkors/NoCommonsNET/releases/tag/${{ steps.gitversion.outputs.NuGetVersionV2 }}" -o ./releases
       - name: Publish
-        run: dotnet nuget push ./releases/NoCommons.${{ steps.gitversion.outputs.NuGetVersionV2 }}.nupkg -k=${{ secrets.NUGETORGAPIKEY }} -s=nuget.org
+        run: dotnet nuget push ./releases/NoCommons.${{ steps.gitversion.outputs.NuGetVersionV2 }}-${{ steps.gitversion.outputs.ShortSha }}.nupkg -k=${{ secrets.NUGETORGAPIKEY }} -s=nuget.org
       - run: git log $(git describe --tags --abbrev=0)..HEAD --oneline
       - name: Log commit messages since last release
         id: releasenotes

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           useConfigFile: true
       - name: Pack
-        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} -o ./releases
+        run: dotnet pack --no-build /p:Version=${{ steps.gitversion.outputs.NuGetVersionV2 }} /p:InformationalVersion=${{ steps.gitversion.outputs.informationalVersion }} /p:PackageReleaseNotes="https://github.com/johnkors/NoCommonsNET/releases/tag/${{ steps.gitversion.outputs.NuGetVersionV2 }}" -o ./releases
       - name: Publish
         run: dotnet nuget push ./releases/NoCommons.${{ steps.gitversion.outputs.NuGetVersionV2 }}.nupkg -k=${{ secrets.NUGETORGAPIKEY }} -s=nuget.org
       - run: git log $(git describe --tags --abbrev=0)..HEAD --oneline

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,4 @@
 - Open a issue
 - If discussion leads to agreeing to a change by you, create a feature branch: `feature/adds-my-thing`
 - Pull Requests should target `master`
+- Pre-releases are deployed to nuget.org on demand

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Dev requirements
+- .NET 5 SDK
+
+# Workflow
+- Open a issue
+- If discussion leads to agreeing to a change by you, create a feature branch: `feature/adds-my-thing`
+- Pull Requests should target `master`

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -5,13 +5,13 @@ branches:
     tag: ""
   feature:
     regex: ^features?[/-]|(?!^master$|^(hotfix|bugfix)(es)?[/-]|^support[/-]|(^(pull|pull\-requests|pr)[/-]))(^.*$)
-    mode: Mainline
+    mode: ContinuousDeployment
     tag: "feature"
   pull-request:
     tag: "pull"
-    mode: Mainline
+    mode: ContinuousDeployment
   hotfix:
     regex: ^(hotfix|bugfix)(es)?[/-]
-    mode: Mainline
+    mode: ContinuousDeployment
     increment: Inherit
     tag: "bug"

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -5,10 +5,13 @@ branches:
     tag: ""
   feature:
     regex: ^features?[/-]|(?!^master$|^(hotfix|bugfix)(es)?[/-]|^support[/-]|(^(pull|pull\-requests|pr)[/-]))(^.*$)
+    mode: Mainline
     tag: "feature"
   pull-request:
     tag: "pull"
+    mode: Mainline
   hotfix:
     regex: ^(hotfix|bugfix)(es)?[/-]
+    mode: Mainline
     increment: Inherit
     tag: "bug"

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2010-2016 Google, Inc. http://angularjs.org
+Copyright (c) 2010-2016 John Korsnes
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/NoCommons.Tests/Banking/KidnummerValidatorTests.cs
+++ b/NoCommons.Tests/Banking/KidnummerValidatorTests.cs
@@ -13,7 +13,7 @@ namespace NoCommons.Tests.Banking
         private const string KIDNUMMER_INVALID_LENGTH_SHORT = "1";
         private const string KIDNUMMER_INVALID_LENGTH_LONG = "12345678901234567890123456";
         
-        protected void assertMessageContains(ArgumentException e, String message)
+        protected void assertMessageContains(ArgumentException e, string message)
         {
             Assert.Contains(message, e.Message);
         }

--- a/NoCommons.Tests/Date/NorwegianDateUtilTests.cs
+++ b/NoCommons.Tests/Date/NorwegianDateUtilTests.cs
@@ -12,7 +12,7 @@ namespace NoCommons.Tests.Date
         public void testAdd2DaysWithinSameWeek()
         {
             var date = new DateTime(2007,3,21);
-            var newDate = NorwegianDateUtil.addWorkingDaysToDate(date, 2);
+            var newDate = NorwegianDateUtil.AddWorkingDaysToDate(date, 2);
 
             Assert.Equal(23, newDate.Day);
         }
@@ -21,7 +21,7 @@ namespace NoCommons.Tests.Date
         public void testAdd2DaysToLastDayOfMonth()
         {
             var date = new DateTime(2007, 2, 28);
-            var newDate = NorwegianDateUtil.addWorkingDaysToDate(date, 2);
+            var newDate = NorwegianDateUtil.AddWorkingDaysToDate(date, 2);
 
             Assert.Equal(2, newDate.Day);
             Assert.Equal(3, newDate.Month);
@@ -31,7 +31,7 @@ namespace NoCommons.Tests.Date
         public void testAdd5DaysWithNoHolidays()
         {
             var date = new DateTime(2007, 03, 21);
-            var newDate = NorwegianDateUtil.addWorkingDaysToDate(date, 5);
+            var newDate = NorwegianDateUtil.AddWorkingDaysToDate(date, 5);
 
             Assert.Equal(28, newDate.Day);
         }
@@ -40,7 +40,7 @@ namespace NoCommons.Tests.Date
         public void testAdd5DaysBeforeEasterHoliday()
         {
             var date = new DateTime(2007, 4, 4);
-            var newDate = NorwegianDateUtil.addWorkingDaysToDate(date, 5);
+            var newDate = NorwegianDateUtil.AddWorkingDaysToDate(date, 5);
 
             Assert.Equal(16, newDate.Day);
         }
@@ -49,7 +49,7 @@ namespace NoCommons.Tests.Date
         public void testAdd5DaysBeforeNationalDay()
         {
             var date = new DateTime(2007, 5, 16);
-            var newDate = NorwegianDateUtil.addWorkingDaysToDate(date, 5);
+            var newDate = NorwegianDateUtil.AddWorkingDaysToDate(date, 5);
 
             Assert.Equal(24, newDate.Day);
         }
@@ -58,7 +58,7 @@ namespace NoCommons.Tests.Date
         public void testAdd5DaysBeforeChristmas()
         {
             var date = new DateTime(2007, 12, 21);
-            var newDate =  NorwegianDateUtil.addWorkingDaysToDate(date, 5);
+            var newDate =  NorwegianDateUtil.AddWorkingDaysToDate(date, 5);
 
             Assert.Equal(2, newDate.Day);
             Assert.Equal(1, newDate.Month);
@@ -68,10 +68,10 @@ namespace NoCommons.Tests.Date
         [Fact]
         public void testWorkingDays()
         {
-            Assert.False(NorwegianDateUtil.isWorkingDay(new DateTime(2007,3,25)), "Sunday not working day");
-            Assert.True(NorwegianDateUtil.isWorkingDay(new DateTime(2007, 3, 26)), "Monday is working day");
-            Assert.False(NorwegianDateUtil.isWorkingDay(new DateTime(2007,1,1)), "New years day not working day");
-            Assert.False(NorwegianDateUtil.isWorkingDay(new DateTime(2007,4,8)), "Easter day not working day");
+            Assert.False(NorwegianDateUtil.IsWorkingDay(new DateTime(2007,3,25)), "Sunday not working day");
+            Assert.True(NorwegianDateUtil.IsWorkingDay(new DateTime(2007, 3, 26)), "Monday is working day");
+            Assert.False(NorwegianDateUtil.IsWorkingDay(new DateTime(2007,1,1)), "New years day not working day");
+            Assert.False(NorwegianDateUtil.IsWorkingDay(new DateTime(2007,4,8)), "Easter day not working day");
         }
 
         [Fact]
@@ -109,7 +109,7 @@ namespace NoCommons.Tests.Date
         public void testGetAllNorwegianHolidaysForYear()
         {
             const string format = "dd.MM.yyyy";
-            var holidays = NorwegianDateUtil.getHolidays(2008);
+            var holidays = NorwegianDateUtil.GetHolidays(2008);
             Assert.Equal(12, holidays.Count());
             Assert.Equal("01.01.2008", holidays.ElementAt(0).ToString(format));
             Assert.Equal("16.03.2008", holidays.ElementAt(1).ToString(format));
@@ -125,10 +125,10 @@ namespace NoCommons.Tests.Date
             Assert.Equal("26.12.2008", holidays.ElementAt(11).ToString(format));
         }
 
-        private void checkHoliday(String date)
+        private void checkHoliday(string date)
         {
             var dateTime = DateTime.ParseExact(date, "dd.MM.yyyy", CultureInfo.InvariantCulture);
-            Assert.True(NorwegianDateUtil.isHoliday(dateTime));
+            Assert.True(NorwegianDateUtil.IsHoliday(dateTime));
         }
     }
 }

--- a/NoCommons.Tests/Person/FodselsnummerCalculatorTests.cs
+++ b/NoCommons.Tests/Person/FodselsnummerCalculatorTests.cs
@@ -19,28 +19,28 @@ namespace NoCommons.Tests.Person
         [Fact]
         public void testGetFodselsnummerForDateAndGender()
         {
-            List<Fodselsnummer> options = FodselsnummerCalculator.getFodselsnummerForDateAndGender(date, KJONN.KVINNE);
+            List<Fodselsnummer> options = FodselsnummerCalculator.GetFodselsnummerForDateAndGender(date, KJONN.KVINNE);
             Assert.Equal(207, options.Count);
         }
 
         [Fact]
         public void getValidFodselsnummerForDate()
         {
-            List<Fodselsnummer> validOptions = FodselsnummerCalculator.getManyFodselsnummerForDate(date);
+            List<Fodselsnummer> validOptions = FodselsnummerCalculator.GetManyFodselsnummerForDate(date);
             Assert.True(validOptions.Count == 412, "Forventet 412 fødselsnumre, men fikk " + validOptions.Count);
         }
 
         [Fact]
         public void getValidFodselsnummerForDNumberDate()
         {
-            List<Fodselsnummer> validOptions = FodselsnummerCalculator.getManyFodselsnummerForDate(date, true);
+            List<Fodselsnummer> validOptions = FodselsnummerCalculator.GetManyFodselsnummerForDate(date, true);
             Assert.True(validOptions.Count == 413, "Forventet 412 fødselsnumre som er d-nummer, men fikk " + validOptions.Count);
         }
 
         [Fact]
         public void testThatAllGeneratedNumbersAreValid()
         {
-            foreach (Fodselsnummer fnr in FodselsnummerCalculator.getManyFodselsnummerForDate(date))
+            foreach (Fodselsnummer fnr in FodselsnummerCalculator.GetManyFodselsnummerForDate(date))
             {
                 Assert.True(FodselsnummerValidator.IsValid(fnr.ToString()), "Ugyldig fødselsnummer: " + fnr);
             }
@@ -49,7 +49,7 @@ namespace NoCommons.Tests.Person
         [Fact]
         public void testThatAllGeneratedDFodselsnumbersAreValid()
         {
-            foreach (Fodselsnummer fnr in FodselsnummerCalculator.getManyFodselsnummerForDate(date, true))
+            foreach (Fodselsnummer fnr in FodselsnummerCalculator.GetManyFodselsnummerForDate(date, true))
             {
                 Assert.True(FodselsnummerValidator.IsValid(fnr.ToString()), "Ugyldig fødselsnummer: " + fnr);
             }
@@ -59,7 +59,7 @@ namespace NoCommons.Tests.Person
         public void testInvalidDateTooEarly()
         {
             date = DateTime.ParseExact("09091853", _dateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None);
-            List<Fodselsnummer> options = FodselsnummerCalculator.getManyFodselsnummerForDate(date);
+            List<Fodselsnummer> options = FodselsnummerCalculator.GetManyFodselsnummerForDate(date);
             Assert.Empty(options);
         }
 
@@ -67,7 +67,7 @@ namespace NoCommons.Tests.Person
         public void testInvalidDateTooLate()
         {
             date = DateTime.ParseExact("09092040", _dateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None);
-            List<Fodselsnummer> options = FodselsnummerCalculator.getManyFodselsnummerForDate(date);
+            List<Fodselsnummer> options = FodselsnummerCalculator.GetManyFodselsnummerForDate(date);
             Assert.Empty(options);
         }
 
@@ -75,7 +75,7 @@ namespace NoCommons.Tests.Person
         public void testOneFodselsnummer()
         {
             date = DateTime.ParseExact("01121980", _dateFormat, CultureInfo.InvariantCulture, DateTimeStyles.None);
-            Fodselsnummer fodselsnummer = FodselsnummerCalculator.getFodselsnummerForDate(date);
+            Fodselsnummer fodselsnummer = FodselsnummerCalculator.GetFodselsnummerForDate(date);
             Assert.True(FodselsnummerValidator.IsValid(fodselsnummer.ToString()));
         }
     }

--- a/NoCommons.Tests/Person/FodselsnummerTests.cs
+++ b/NoCommons.Tests/Person/FodselsnummerTests.cs
@@ -17,134 +17,134 @@ namespace NoCommons.Tests.Person
 
         [Fact]
         public void testGetDateAndMonth() {
-	        Assert.Equal("0101", sut.getDateAndMonth());
+	        Assert.Equal("0101", sut.GetDateAndMonth());
         }
 
         [Fact]
         public void testGetDayInMonth() {
-	        Assert.Equal("01", sut.getDayInMonth());
+	        Assert.Equal("01", sut.GetDayInMonth());
 	        sut = new Fodselsnummer(VALID_D_FODSELSNUMMER);
-	        Assert.Equal("01", sut.getDayInMonth());
+	        Assert.Equal("01", sut.GetDayInMonth());
         }
 
         [Fact]
         public void testGetMonth() {
-	        Assert.Equal("01", sut.getMonth());
+	        Assert.Equal("01", sut.GetMonth());
         }
 
         [Fact]
         public void testGetDateAndMonthDNumber() {
 	        sut = new Fodselsnummer(VALID_D_FODSELSNUMMER);
-	        Assert.Equal("0101", sut.getDateAndMonth());
+	        Assert.Equal("0101", sut.GetDateAndMonth());
         }
 
         [Fact]
         public void testGetCentury() {
 	        sut = new Fodselsnummer("01016666609");
-	        Assert.Equal("18", sut.getCentury());
+	        Assert.Equal("18", sut.GetCentury());
 
 	        sut = new Fodselsnummer("01016633301");
-	        Assert.Equal("19", sut.getCentury());
+	        Assert.Equal("19", sut.GetCentury());
 
 	        sut = new Fodselsnummer("01019196697");
-	        Assert.Equal("19", sut.getCentury());
+	        Assert.Equal("19", sut.GetCentury());
 
 	        sut = new Fodselsnummer("01013366671");
-	        Assert.Equal("20", sut.getCentury());
+	        Assert.Equal("20", sut.GetCentury());
 
 	        // DNumber...
 	        sut = new Fodselsnummer("41016666609");
-	        Assert.Equal("18", sut.getCentury());
+	        Assert.Equal("18", sut.GetCentury());
 
             sut = new Fodselsnummer("01015466609");
-            Assert.Equal("18", sut.getCentury());
+            Assert.Equal("18", sut.GetCentury());
 
             sut = new Fodselsnummer("41016633301");
-	        Assert.Equal("19", sut.getCentury());
+	        Assert.Equal("19", sut.GetCentury());
 
 	        sut = new Fodselsnummer("41019196697");
-	        Assert.Equal("19", sut.getCentury());
+	        Assert.Equal("19", sut.GetCentury());
 
 	        sut = new Fodselsnummer("41013366671");
-	        Assert.Equal("20", sut.getCentury());
+	        Assert.Equal("20", sut.GetCentury());
         }
 
         [Fact]
         public void testGet2DigitBirthYear() {
-	        Assert.Equal("01", sut.get2DigitBirthYear());
+	        Assert.Equal("01", sut.Get2DigitBirthYear());
         }
 
         [Fact]
         public void testGetBirthYear() {
-	        Assert.Equal("1901", sut.getBirthYear());
+	        Assert.Equal("1901", sut.GetBirthYear());
 	        sut = new Fodselsnummer(VALID_D_FODSELSNUMMER);
-	        Assert.Equal("1901", sut.getBirthYear());
+	        Assert.Equal("1901", sut.GetBirthYear());
         }
 
         [Fact]
         public void testGetDateOfBirth() {
-	        Assert.Equal("010101", sut.getDateOfBirth());
+	        Assert.Equal("010101", sut.GetDateOfBirth());
         }
 
         [Fact]
         public void testGetDateOfBirthDNumber() {
 	        sut = new Fodselsnummer(VALID_D_FODSELSNUMMER);
-	        Assert.Equal("010101", sut.getDateOfBirth());
+	        Assert.Equal("010101", sut.GetDateOfBirth());
         }
 
         [Fact]
         public void testGetPersonnummer() {
-	        Assert.Equal("23476", sut.getPersonnummer());
+	        Assert.Equal("23476", sut.GetPersonnummer());
         }
 
         [Fact]
         public void testGetIndividnummer() {
-	        Assert.Equal("234", sut.getIndividnummer());
+	        Assert.Equal("234", sut.GetIndividnummer());
         }
 
         [Fact]
         public void testGetGenderDigit() {
-	        Assert.Equal(4, sut.getGenderDigit());
+	        Assert.Equal(4, sut.GetGenderDigit());
         }
 
         [Fact]
         public void testGetChecksumDigits() {
-	        Assert.Equal(7, sut.getChecksumDigit1());
-	        Assert.Equal(6, sut.getChecksumDigit2());
+	        Assert.Equal(7, sut.GetChecksumDigit1());
+	        Assert.Equal(6, sut.GetChecksumDigit2());
         }
 
         [Fact]
         public void testIsMale() {
-	        Assert.False(sut.isMale());
+	        Assert.False(sut.IsMale());
         }
 
         [Fact]
         public void testIsMaleDNumber() {
 	        sut = new Fodselsnummer(VALID_D_FODSELSNUMMER);
-	        Assert.False(sut.isMale());
+	        Assert.False(sut.IsMale());
         }
 
         [Fact]
         public void testIsFemale() {
-	        Assert.True(sut.isFemale());
+	        Assert.True(sut.IsFemale());
         }
 
         [Fact]
         public void testIsFemaleDNumber() {
 	        sut = new Fodselsnummer(VALID_D_FODSELSNUMMER);
-	        Assert.True(sut.isFemale());
+	        Assert.True(sut.IsFemale());
         }
 
         [Fact]
         public void testIsDNumber() {
-	        Assert.False(Fodselsnummer.isDNumber("01010101006"));
-	        Assert.False(Fodselsnummer.isDNumber("80000000000"));
-	        Assert.True(Fodselsnummer.isDNumber("47086303651"));
+	        Assert.False(Fodselsnummer.IsDNumber("01010101006"));
+	        Assert.False(Fodselsnummer.IsDNumber("80000000000"));
+	        Assert.True(Fodselsnummer.IsDNumber("47086303651"));
         }
 
         [Fact]
         public void testParseDNumber() {
-	        Assert.Equal("07086303651", Fodselsnummer.parseDNumber("47086303651"));
+	        Assert.Equal("07086303651", Fodselsnummer.ParseDNumber("47086303651"));
         }
     }
 }

--- a/NoCommons/Banking/KidnummerValidator.cs
+++ b/NoCommons/Banking/KidnummerValidator.cs
@@ -13,13 +13,13 @@ namespace NoCommons.Banking
         public const string ERROR_LENGTH = "A Kidnummer is between 2 and 25 digits";
 
         /**
-	     * Return true if the provided String is a valid KID-nummmer.
+	     * Return true if the provided string is a valid KID-nummmer.
 	     * 
 	     * @param kidnummer
-	     *            A String containing a Kidnummer
+	     *            A string containing a Kidnummer
 	     * @return true or false
 	     */
-        public static bool IsValid(String kidnummer) {
+        public static bool IsValid(string kidnummer) {
             try {
                 GetKidnummer(kidnummer);
                 return true;
@@ -32,10 +32,10 @@ namespace NoCommons.Banking
 	     * Returns an object that represents a Kidnummer.
 	     * 
 	     * @param kidnummer
-	     *            A String containing a Kidnummer
+	     *            A string containing a Kidnummer
 	     * @return A Kidnummer instance
 	     * @throws IllegalArgumentException
-	     *             thrown if String contains an invalid Kidnummer
+	     *             thrown if string contains an invalid Kidnummer
 	     */
         public static Kidnummer GetKidnummer(string kidnummer) {
             ValidateSyntax(kidnummer);
@@ -54,7 +54,7 @@ namespace NoCommons.Banking
             }
         }
 
-        internal static void ValidateChecksum(String kidnummer) {
+        internal static void ValidateChecksum(string kidnummer) {
             StringNumber k = new Kidnummer(kidnummer);
             int kMod10 = CalculateMod10CheckSum(GetMod10Weights(k), k);
             int kMod11 = CalculateMod11CheckSum(GetMod11Weights(k), k);

--- a/NoCommons/Banking/KontonummerCalculator.cs
+++ b/NoCommons/Banking/KontonummerCalculator.cs
@@ -36,7 +36,7 @@ namespace NoCommons.Banking
 	     * for a given AccountType.
 	     * 
 	     * @param accountType
-	     *            A String representing the AccountType to use for all
+	     *            A string representing the AccountType to use for all
 	     *            Kontonummer instances
 	     * @param length
 	     *            Specifies the number of Kontonummer instances to create in the
@@ -55,7 +55,7 @@ namespace NoCommons.Banking
 	     * for a given Registernummer.
 	     * 
 	     * @param registernummer
-	     *            A String representing the Registernummer to use for all
+	     *            A string representing the Registernummer to use for all
 	     *            Kontonummer instances
 	     * @param length
 	     *            Specifies the number of Kontonummer instances to create in the
@@ -98,7 +98,7 @@ namespace NoCommons.Banking
 
         private readonly string _accountType;
 
-        internal AccountTypeKontonrDigitGenerator(String accountType)
+        internal AccountTypeKontonrDigitGenerator(string accountType)
         {
             _accountType = accountType;
         }
@@ -129,7 +129,7 @@ namespace NoCommons.Banking
     {
         private readonly string _registerNr;
 
-        internal RegisternummerKontonrDigitGenerator(String registerNr)
+        internal RegisternummerKontonrDigitGenerator(string registerNr)
         {
             _registerNr = registerNr;
         }

--- a/NoCommons/Date/NorwegianDateUtil.cs
+++ b/NoCommons/Date/NorwegianDateUtil.cs
@@ -25,14 +25,14 @@ namespace NoCommons.Date
         /// <param name="date">The original date</param>
         /// <param name="days">The number of working days to add</param>
         /// <returns>The new date</returns>
-        public static DateTime addWorkingDaysToDate(DateTime date, int days)
+        public static DateTime AddWorkingDaysToDate(DateTime date, int days)
         {
 
             var localDate = date;
             for (var i = 0; i < days; i++)
             {
                 localDate = localDate.AddDays(1);
-                while (!isWorkingDay(localDate))
+                while (!IsWorkingDay(localDate))
                 {
                     localDate = localDate.AddDays(1);
                 }
@@ -47,10 +47,10 @@ namespace NoCommons.Date
         /// </summary>
         /// <param name="date">The date to check</param>
         /// <returns>true if the given date is a working day, false otherwise</returns>
-        public static bool isWorkingDay(DateTime date)
+        public static bool IsWorkingDay(DateTime date)
         {
             return date.DayOfWeek != DayOfWeek.Saturday && date.DayOfWeek != DayOfWeek.Sunday
-                   && !isHoliday(date);
+                   && !IsHoliday(date);
         }
 
         /// <summary>
@@ -58,13 +58,13 @@ namespace NoCommons.Date
         /// </summary>
         /// <param name="date">date to check if is a holiday</param>
         /// <returns>true if holiday, false otherwise</returns>
-        public static bool isHoliday(DateTime date)
+        public static bool IsHoliday(DateTime date)
         {
             var year = date.Year;
-            var holidaysForYear = getHolidaySet(year);
+            var holidaysForYear = GetHolidaySet(year);
             foreach (var holiday in holidaysForYear)
             {  
-                if (checkDate(date, holiday))
+                if (CheckDate(date, holiday))
                 {
                     return true;
                 }
@@ -77,9 +77,9 @@ namespace NoCommons.Date
         /// </summary>
         /// <param name="year">The year to get holidays for</param>
         /// <returns>Holidays, sorted by date</returns>
-        public static IEnumerable<DateTime> getHolidays(int year)
+        public static IEnumerable<DateTime> GetHolidays(int year)
         {
-            var days = getHolidaySet(year);
+            var days = GetHolidaySet(year);
             var listOfHolidays = new List<DateTime>(days);
             listOfHolidays.Sort((date1, date2) => date1.CompareTo(date2));
             return listOfHolidays;
@@ -90,7 +90,7 @@ namespace NoCommons.Date
         /// </summary>
         /// <param name="year">The year to get holidays for</param>
         /// <returns>Holidays for year</returns>
-        private static IEnumerable<DateTime> getHolidaySet(int year)
+        private static IEnumerable<DateTime> GetHolidaySet(int year)
         {
             lock (Lock)
             {
@@ -110,7 +110,7 @@ namespace NoCommons.Date
                     yearSet.Add(new DateTime(year, 12, 26));
 
                     // Add movable holidays - based on easter day.
-                    var easterDay = getEasterDay(year);
+                    var easterDay = GetEasterDay(year);
 
                     // Sunday before easter.
                     yearSet.Add(easterDay.AddDays(-7));
@@ -151,7 +151,7 @@ namespace NoCommons.Date
        /// </summary>
        /// <param name="year">year</param>
        /// <returns>easterday for year</returns>
-        private static DateTime getEasterDay(int year)
+        private static DateTime GetEasterDay(int year)
         {
             int a = year%19;
             int b = year/100;
@@ -171,7 +171,7 @@ namespace NoCommons.Date
             return new DateTime(year, n, p + 1);
         }
 
-        private static bool checkDate(DateTime date, DateTime other)
+        private static bool CheckDate(DateTime date, DateTime other)
         {
             return date.Day == other.Day && date.Month == other.Month;
         }

--- a/NoCommons/NoCommons.csproj
+++ b/NoCommons/NoCommons.csproj
@@ -4,9 +4,7 @@
     <AssemblyName>NoCommons</AssemblyName>
     <PackageId>NoCommons</PackageId>    
     <Authors>John Korsnes</Authors>
-    <Description>Hjelpeklasser for validering og generering av data tilknyttet norske domener. </Description>
-    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageReleaseNotes>Generering av fødselsnummere som er d-nummere. </PackageReleaseNotes>
+    <Description>Hjelpeklasser for validering og generering av data tilknyttet norske domener. </Description>    
     <PackageIcon>norge.512x512.png</PackageIcon>
     <PackageTags>norway norwegian kontonummer fodselsnummer kidnummer organisasjonsnummer validation generators calculator holidays easter christmas</PackageTags>
   </PropertyGroup>

--- a/NoCommons/NoCommons.csproj
+++ b/NoCommons/NoCommons.csproj
@@ -11,6 +11,6 @@
     <PackageTags>norway norwegian kontonummer fodselsnummer kidnummer organisasjonsnummer validation generators calculator holidays easter christmas</PackageTags>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="Images\norge.512x512.png" Pack="true" PackagePath=""/>
+    <None Include="Images\norge.512x512.png" Pack="true" PackagePath="" />
   </ItemGroup>
  </Project>

--- a/NoCommons/Person/Fodselsnummer.cs
+++ b/NoCommons/Person/Fodselsnummer.cs
@@ -11,7 +11,7 @@ namespace NoCommons.Person
      */
     public class Fodselsnummer : StringNumber {
 
-        public Fodselsnummer(String fodselsnummer) : base(fodselsnummer) {
+        public Fodselsnummer(string fodselsnummer) : base(fodselsnummer) {
 		
         }
 
@@ -19,45 +19,45 @@ namespace NoCommons.Person
 	        * Returns the first 4 digits of the Fodselsnummer that contains the date
 	        * (01-31) and month(01-12) of birth.
 	        *
-	        * @return A String containing the date and month of birth.
+	        * @return A string containing the date and month of birth.
 	        */
-        public String getDateAndMonth() {
-	        return parseDNumber(GetValue()).Substring(0, 4);
+        public string GetDateAndMonth() {
+	        return ParseDNumber(GetValue()).Substring(0, 4);
         }
 
         /**
 	        * Returns the first 2 digits of the Fodselsnummer that contains the date
 	        * (01-31), stripped for eventual d-numbers.
 	        *
-	        * @return A String containing the date of birth
+	        * @return A string containing the date of birth
 	        */
-        public String getDayInMonth() {
-	        return parseDNumber(GetValue()).Substring(0, 2);
+        public string GetDayInMonth() {
+	        return ParseDNumber(GetValue()).Substring(0, 2);
         }
 
         /**
 	        * Returns the digits 3 and 4 of the Fodselsnummer that contains the month
 	        * (01-12), stripped for eventual d-numbers.
 	        *
-	        * @return A String containing the date of birth
+	        * @return A string containing the date of birth
 	        */
-        public String getMonth() {
-	        return parseDNumber(GetValue()).Substring(2, 2);
+        public string GetMonth() {
+	        return ParseDNumber(GetValue()).Substring(2, 2);
         }
 
         /**
 	        * Returns the birthyear of the Fodselsnummer
 	        *
-	        * @return A String containing the year of birth.
+	        * @return A string containing the year of birth.
 	        */
-        public String getBirthYear() {
-	        return getCentury() + get2DigitBirthYear();
+        public string GetBirthYear() {
+	        return GetCentury() + Get2DigitBirthYear();
         }
 
-        public String getCentury() {
-	        String result = null;
-	        int individnummerInt = int.Parse(getIndividnummer());
-	        int birthYear = int.Parse(get2DigitBirthYear());
+        public string GetCentury() {
+	        string result = null;
+	        int individnummerInt = int.Parse(GetIndividnummer());
+	        int birthYear = int.Parse(Get2DigitBirthYear());
 	        if (individnummerInt <= 499) {
 		        result = "19";
 	        } else if (individnummerInt >= 500 && birthYear < 40) {
@@ -74,9 +74,9 @@ namespace NoCommons.Person
 	        * Returns the two digits of the Fodselsnummer that contains the year birth
 	        * (00-99).
 	        *
-	        * @return A String containing the year of birth.
+	        * @return A string containing the year of birth.
 	        */
-        public String get2DigitBirthYear() {
+        public string Get2DigitBirthYear() {
 	        return GetValue().Substring(4, 2);
         }
 
@@ -84,10 +84,10 @@ namespace NoCommons.Person
 	        * Returns the first 6 digits of the Fodselsnummer that contains the date
 	        * (01-31), month(01-12) and year(00-99) of birth.
 	        *
-	        * @return A String containing the date and month of birth.
+	        * @return A string containing the date and month of birth.
 	        */
-        public String getDateOfBirth() {
-	        return parseDNumber(GetValue()).Substring(0, 6);
+        public string GetDateOfBirth() {
+	        return ParseDNumber(GetValue()).Substring(0, 6);
         }
 
         /**
@@ -95,9 +95,9 @@ namespace NoCommons.Person
 	        * Personnummer. The Personnummer consists of the Individnummer (3 digits)
 	        * and two checksum digits.
 	        *
-	        * @return A String containing the Personnummer.
+	        * @return A string containing the Personnummer.
 	        */
-        public String getPersonnummer() {
+        public string GetPersonnummer() {
 	        return GetValue().Substring(6);
         }
 
@@ -105,9 +105,9 @@ namespace NoCommons.Person
 	        * Returns the first three digits of the Personnummer, also known as the
 	        * Individnummer.
 	        *
-	        * @return A String containing the Individnummer.
+	        * @return A string containing the Individnummer.
 	        */
-        public String getIndividnummer() {
+        public string GetIndividnummer() {
 	        return GetValue().Substring(6, 3);
         }
 
@@ -116,7 +116,7 @@ namespace NoCommons.Person
 	        *
 	        * @return The digit.
 	        */
-        public int getGenderDigit() {
+        public int GetGenderDigit() {
 	        return GetAt(8);
         }
 
@@ -125,7 +125,7 @@ namespace NoCommons.Person
 	        *
 	        * @return The digit.
 	        */
-        public int getChecksumDigit1() {
+        public int GetChecksumDigit1() {
 	        return GetAt(9);
         }
 
@@ -134,7 +134,7 @@ namespace NoCommons.Person
 	        *
 	        * @return The digit.
 	        */
-        public int getChecksumDigit2() {
+        public int GetChecksumDigit2() {
 	        return GetAt(10);
         }
 
@@ -143,8 +143,8 @@ namespace NoCommons.Person
 	        *
 	        * @return true or false.
 	        */
-        public bool isMale() {
-	        return getGenderDigit() % 2 != 0;
+        public bool IsMale() {
+	        return GetGenderDigit() % 2 != 0;
         }
 
         /**
@@ -152,13 +152,13 @@ namespace NoCommons.Person
 	        *
 	        * @return true or false.
 	        */
-        public bool isFemale() {
-	        return !isMale();
+        public bool IsFemale() {
+	        return !IsMale();
         }
 
-        public static bool isDNumber(string fodselsnummer) {
+        public static bool IsDNumber(string fodselsnummer) {
 	        try {
-		        int firstDigit = getFirstDigit(fodselsnummer);
+		        int firstDigit = GetFirstDigit(fodselsnummer);
 		        if (firstDigit > 3 && firstDigit < 8) {
 			        return true;
 		        }
@@ -168,20 +168,20 @@ namespace NoCommons.Person
 	        return false;
         }
 
-        public static string parseDNumber(string fodselsnummer) {
-	        if (!isDNumber(fodselsnummer)) {
+        public static string ParseDNumber(string fodselsnummer) {
+	        if (!IsDNumber(fodselsnummer)) {
 		        return fodselsnummer;
 	        } else {
-		        return (getFirstDigit(fodselsnummer) - 4) + fodselsnummer.Substring(1);
+		        return (GetFirstDigit(fodselsnummer) - 4) + fodselsnummer.Substring(1);
 	        }
         }
 
-        private static int getFirstDigit(String fodselsnummer) {
+        private static int GetFirstDigit(string fodselsnummer) {
 	        return int.Parse(fodselsnummer.Substring(0, 1));
         }
 
-        public KJONN getKjonn() {
-	        if (isFemale()) {
+        public KJONN GetKjonn() {
+	        if (IsFemale()) {
 		        return KJONN.KVINNE;
 	        } else {
 		        return KJONN.MANN;

--- a/NoCommons/Person/FodselsnummerCalculator.cs
+++ b/NoCommons/Person/FodselsnummerCalculator.cs
@@ -14,19 +14,19 @@ namespace NoCommons.Person
         /**
          * Returns a List with valid Fodselsnummer instances for a given Date and gender.
          */
-        public static List<Fodselsnummer> getFodselsnummerForDateAndGender(DateTime date, KJONN kjonn)
+        public static List<Fodselsnummer> GetFodselsnummerForDateAndGender(DateTime date, KJONN kjonn)
         {
-            List<Fodselsnummer> result = getManyFodselsnummerForDate(date);
-            result = splitByGender(kjonn, result);
+            List<Fodselsnummer> result = GetManyFodselsnummerForDate(date);
+            result = SplitByGender(kjonn, result);
             return result;
         }
 
         /**
          * Return one random valid fodselsnummer on a given date
          */
-        public static Fodselsnummer getFodselsnummerForDate(DateTime date)
+        public static Fodselsnummer GetFodselsnummerForDate(DateTime date)
         {
-            List<Fodselsnummer> fodselsnummerList = getManyFodselsnummerForDate(date);
+            List<Fodselsnummer> fodselsnummerList = GetManyFodselsnummerForDate(date);
             //Collections.shuffle(fodselsnummerList);
             return fodselsnummerList[0];
         }
@@ -37,13 +37,13 @@ namespace NoCommons.Person
          * @param date The Date instance
          * @return A List with Fodelsnummer instances
          */
-        public static List<Fodselsnummer> getManyFodselsnummerForDate(DateTime date, bool dNumber = false)
+        public static List<Fodselsnummer> GetManyFodselsnummerForDate(DateTime date, bool dNumber = false)
         {
             if (date == null)
             {
                 throw new ArgumentException();
             }
-            var century = getCentury(date);
+            var century = GetCentury(date);
             
             var dateString = date.ToString("ddMMyy");
             if (dNumber)
@@ -52,7 +52,7 @@ namespace NoCommons.Person
                 dateString = $"{day}{date.ToString("MMyy")}";
             }
 
-                var result = new List<Fodselsnummer>();
+            var result = new List<Fodselsnummer>();
             for (int i = 999; i >= 0; i--)
             {
                 var sb = new StringBuilder(dateString);
@@ -74,7 +74,7 @@ namespace NoCommons.Person
                     sb.Append(FodselsnummerValidator.CalculateSecondChecksumDigit(fodselsnummer));
                     fodselsnummer = new Fodselsnummer(sb.ToString());
 
-                    var centuryByIndividnummer = fodselsnummer.getCentury();
+                    var centuryByIndividnummer = fodselsnummer.GetCentury();
                     if (centuryByIndividnummer != null && centuryByIndividnummer.Equals(century) && FodselsnummerValidator.IsValid(fodselsnummer.GetValue()))
                     {
                         result.Add(fodselsnummer);
@@ -88,14 +88,14 @@ namespace NoCommons.Person
             return result;
         }
 
-        private static String getCentury(DateTime date)
+        private static string GetCentury(DateTime date)
         {
             return Convert.ToString(date.Year).Substring(0, 2);
         }
 
-        private static List<Fodselsnummer> splitByGender(KJONN kjonn, List<Fodselsnummer> result)
+        private static List<Fodselsnummer> SplitByGender(KJONN kjonn, List<Fodselsnummer> result)
         {
-            return (from f in result where f.getKjonn() == kjonn select f).ToList();
+            return (from f in result where f.GetKjonn() == kjonn select f).ToList();
             
         }
 

--- a/NoCommons/Person/FodselsnummerValidator.cs
+++ b/NoCommons/Person/FodselsnummerValidator.cs
@@ -17,20 +17,20 @@ namespace NoCommons.Person
         private static readonly int[] K1_WEIGHTS = new [] { 2, 5, 4, 9, 8, 1, 6, 7, 3 };
         private static readonly int[] K2_WEIGHTS = new int[] { 2, 3, 4, 5, 6, 7, 2, 3, 4, 5 };
 
-        public const string ERROR_INVALID_DATE = "Invalid date in fødselsnummer : ";
+        public const string ERROR_INVALID_DATE = "Invalid date in fï¿½dselsnummer : ";
 
-        public const string ERROR_INVALID_INDIVIDNUMMER = "Invalid individnummer in fødselsnummer : ";
+        public const string ERROR_INVALID_INDIVIDNUMMER = "Invalid individnummer in fï¿½dselsnummer : ";
 
         /**
 	     * Returns an object that represents a Fodselsnummer.
 	     * 
 	     * @param fodselsnummer
-	     *            A String containing a Fodselsnummer
+	     *            A string containing a Fodselsnummer
 	     * @return A Fodselsnummer instance
 	     * @throws ArgumentException
-	     *             thrown if String contains an invalid Fodselsnummer
+	     *             thrown if string contains an invalid Fodselsnummer
 	     */
-        public static Fodselsnummer getFodselsnummer(String fodselsnummer) {
+        public static Fodselsnummer getFodselsnummer(string fodselsnummer) {
             ValidateSyntax(fodselsnummer);
             validateIndividnummer(fodselsnummer);
             validateDate(fodselsnummer);
@@ -39,13 +39,13 @@ namespace NoCommons.Person
         }
 
         /**
-	     * Return true if the provided String is a valid Fodselsnummer.
+	     * Return true if the provided string is a valid Fodselsnummer.
 	     * 
 	     * @param fodselsnummer
-	     *            A String containing a Fodselsnummer
+	     *            A string containing a Fodselsnummer
 	     * @return true or false
 	     */
-        public static bool IsValid(String fodselsnummer) {
+        public static bool IsValid(string fodselsnummer) {
             try {
                 getFodselsnummer(fodselsnummer);
                 return true;
@@ -58,28 +58,28 @@ namespace NoCommons.Person
             ValidateLengthAndAllDigits(fodselsnummer, LENGTH);
         }
 
-        public static void validateIndividnummer(String fodselsnummer) {
+        public static void validateIndividnummer(string fodselsnummer) {
             var fnr = new Fodselsnummer(fodselsnummer);
-            if (fnr.getCentury() == null) {
+            if (fnr.GetCentury() == null) {
                 throw new ArgumentException(ERROR_INVALID_INDIVIDNUMMER + fodselsnummer);
             }
         }
 
-        public static void validateDate(String fodselsnummer) {
+        public static void validateDate(string fodselsnummer) {
             var fnr = new Fodselsnummer(fodselsnummer);
             try {
-                var dateString = fnr.getDateAndMonth() + fnr.getCentury() + fnr.get2DigitBirthYear();
+                var dateString = fnr.GetDateAndMonth() + fnr.GetCentury() + fnr.Get2DigitBirthYear();
                 DateTime.ParseExact(dateString, DATE_FORMAT, CultureInfo.InvariantCulture, DateTimeStyles.None);
             } catch (Exception) {
                 throw new ArgumentException(ERROR_INVALID_DATE + fodselsnummer);
             }
         }
 
-        public static void validateChecksums(String fodselsnummer) {
+        public static void validateChecksums(string fodselsnummer) {
             var fnr = new Fodselsnummer(fodselsnummer);
             int k1 = CalculateFirstChecksumDigit(fnr);
             int k2 = CalculateSecondChecksumDigit(fnr);
-            if (k1 != fnr.getChecksumDigit1() || k2 != fnr.getChecksumDigit2()) {
+            if (k1 != fnr.GetChecksumDigit1() || k2 != fnr.GetChecksumDigit2()) {
                 throw new ArgumentException(ERROR_INVALID_CHECKSUM + fodselsnummer);
             }
         }

--- a/NoCommons/Person/KJONN.cs
+++ b/NoCommons/Person/KJONN.cs
@@ -2,7 +2,6 @@ namespace NoCommons.Person
 {
     public enum KJONN
     {
-
         MANN,
         KVINNE,
         BEGGE


### PR DESCRIPTION
- Renames Java-like syntax to C# i.e 'getFoo' -> 'GetFoo'
- Removes netstandard1.3 support, netstandard2 being the lowest